### PR TITLE
Allow setting an empty list for source.group_by

### DIFF
--- a/cpconfig/ds.py
+++ b/cpconfig/ds.py
@@ -56,9 +56,10 @@ class Source:
 
     @cached_property
     def group_by_columns(self) -> List[str]:
-        return self.group_by or (
-            ["cp_user_id", "cp_date"] if self.cp_user_id and self.cp_date else []
-        )
+        if self.group_by is not None:
+            return self.group_by
+        return ["cp_user_id", "cp_date"] if self.cp_user_id and self.cp_date else []
+
 
     @cached_property
     def join_using_columns(self) -> List[str]:


### PR DESCRIPTION
## Context

For each source, we might wanna set an empty list of `group_by` columns. For example:

```
sources:
  - name: tbl1
    group_by: []
```

This is needed when the source table is already "flat" (one user-date per row).

However python treats an empty array as `False` in a `if` check, which leads to the incorrect final list of group by columns.

## Changes

Make it clear we're checking for `None` (meaning no `group_by` field in the config file) in `Source.group_by_columns` attribute

## Verification

Tested output of 3 client projects.